### PR TITLE
8.0.1 fixes #23

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -204,7 +204,7 @@ end)
 local IsControlKeyDown, IsShiftKeyDown = IsControlKeyDown, IsShiftKeyDown
 
 local bottomButton = setmetatable({}, { __index = function(t, self)
-	local button = _G[self:GetName() .. "ButtonFrameBottomButton"]
+	local button = _G[self:GetName()]["ScrollToBottomButton"]
 	t[self] = button
 	return button
 end })

--- a/Modules/HideButtons.lua
+++ b/Modules/HideButtons.lua
@@ -22,36 +22,28 @@ local function BottomButton_OnClick(self, button)
 	else
 		frame:GetParent():ScrollToBottom()
 	end
-	_G[frame:GetName() .. "ButtonFrameBottomButton"]:Hide()
+	_G[frame:GetName()]["ScrollToBottomButton"]:Hide()
 end
 
 local function ChatFrame_OnShow(self)
 	if not PhanxChat.db.HideButtons then return end
 	if self:AtBottom() then
-		_G[self:GetName() .. "ButtonFrameBottomButton"]:Hide()
+		_G[self:GetName()]["ScrollToBottomButton"]:Hide()
 	else
-		_G[self:GetName() .. "ButtonFrameBottomButton"]:Show()
+		_G[self:GetName()]["ScrollToBottomButton"]:Show()
 	end
 end
 
 function PhanxChat:HideButtons(frame)
 	local name = frame:GetName()
 	local buttonFrame = _G[name .. "ButtonFrame"]
-	local upButton = _G[name .. "ButtonFrameUpButton"]
-	local downButton = _G[name .. "ButtonFrameDownButton"]
-	local bottomButton = _G[name .. "ButtonFrameBottomButton"]
-
+	local bottomButton = _G[name]["ScrollToBottomButton"]
 	frame:HookScript("OnShow", ChatFrame_OnShow)
 
 	if self.db.HideButtons then
 		buttonFrame.Show = noop
 		buttonFrame:Hide()
 
-		upButton.Show = noop
-		upButton:Hide()
-
-		downButton.Show = noop
-		downButton:Hide()
 
 		bottomButton:ClearAllPoints()
 		bottomButton:SetParent(frame)
@@ -69,13 +61,6 @@ function PhanxChat:HideButtons(frame)
 	else
 		buttonFrame.Show = nil
 		buttonFrame:Show()
-
-		upButton.Show = nil
-		upButton:Show()
-
-		downButton.Show = nil
-		downButton:Show()
-
 		bottomButton:ClearAllPoints()
 		bottomButton:SetParent(buttonFrame)
 		bottomButton:SetPoint("BOTTOM", buttonFrame, "BOTTOM", 0, -7)
@@ -111,8 +96,8 @@ function PhanxChat:SetHideButtons(v)
 		QuickJoinToastButton:Hide()
 
 		if not self.hooks.BN_TOAST_LEFT_OFFSET then
-			self.hooks.BN_TOAST_LEFT_OFFSET = BN_TOAST_LEFT_OFFSET
-			BN_TOAST_LEFT_OFFSET = BN_TOAST_LEFT_OFFSET + ChatFrame1ButtonFrame:GetWidth() + 5
+			self.hooks.BN_TOAST_LEFT_OFFSET = 1
+			BN_TOAST_LEFT_OFFSET = 1 + ChatFrame1ButtonFrame:GetWidth() + 5
 		end
 	elseif not self.isLoading then
 		ChatFrameMenuButton:SetScript("OnShow", nil)

--- a/Modules/ReplaceRealNames.lua
+++ b/Modules/ReplaceRealNames.lua
@@ -100,12 +100,10 @@ function PhanxChat:SetReplaceRealNames(v)
 	if self.db.ReplaceRealNames or self.db.ShortenRealNames then
 		self:RegisterEvent("BN_CONNECTED")
 		self:RegisterEvent("BN_FRIEND_ACCOUNT_ONLINE")
-		self:RegisterEvent("BN_FRIEND_TOON_ONLINE")
 		self:RegisterEvent("PLAYER_ENTERING_WORLD")
 	else
 		self:UnregisterEvent("BN_CONNECTED")
 		self:UnregisterEvent("BN_FRIEND_ACCOUNT_ONLINE")
-		self:UnregisterEvent("BN_FRIEND_TOON_ONLINE")
 		self:UnregisterEvent("PLAYER_ENTERING_WORLD")
 	end
 end


### PR DESCRIPTION
Fixes required to make this work in 8.0.1

Key changes to API:

- [x] BN_FRIEND_TOON_ONLINE: Not supported anymore (?) [This](https://us.battle.net/forums/en/wow/topic/20762318007) causes it not to work.
> Attempting to register or unregister for an unknown event will now generate a Lua error

Key changes to UI:
- [x] Up and Down buttons do not exist anymore and scroll to bottom button name has been changed.

Key changes to GlobalStrings:
- [x] BN_TOAST_LEFT_OFFSET: Removed (?) therefore the variable is changed it to 1 (which was the original value).